### PR TITLE
mutate: add uncompressed blob size annotation

### DIFF
--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -214,6 +214,7 @@ func TestMutateAdd(t *testing.T) {
 
 	// This isn't a valid image, but whatever.
 	buffer := bytes.NewBufferString("contents")
+	bufferSize := buffer.Len()
 
 	// Add a new layer.
 	annotations := map[string]string{"hello": "world"}
@@ -253,10 +254,18 @@ func TestMutateAdd(t *testing.T) {
 	if mutator.manifest.Layers[1].Digest == expectedLayerDigest {
 		t.Errorf("manifest.Layers[1].Digest is not the same!")
 	}
-	if len(mutator.manifest.Layers[1].Annotations) != 1 || mutator.manifest.Layers[1].Annotations["hello"] != "world" {
-		t.Errorf("manifest.Layers[1].Annotations was not set correctly!")
+	if len(mutator.manifest.Layers[1].Annotations) != 2 {
+		t.Errorf("manifest.Layers[1].Annotations was not set correctly!: %+v", mutator.manifest.Layers[1].Annotations)
 	}
-
+	if mutator.manifest.Layers[1].Annotations["hello"] != "world" {
+		t.Errorf("manifest.Layers[1].Annotations['hello'] was not set correctly!: %+v", mutator.manifest.Layers[1].Annotations)
+	}
+	if mutator.manifest.Layers[1].Annotations[UmociUncompressedBlobSizeAnnotation] != fmt.Sprintf("%d", bufferSize) {
+		t.Errorf("manifest.Layers[1].Annotations['%s'] was not set correctly!: %q, expected %d",
+			UmociUncompressedBlobSizeAnnotation,
+			mutator.manifest.Layers[1].Annotations[UmociUncompressedBlobSizeAnnotation],
+			bufferSize)
+	}
 	if mutator.manifest.Layers[1].Digest != newLayerDesc.Digest {
 		t.Fatalf("unexpected digest for new layer: %v %v", mutator.manifest.Layers[1].Digest, newLayerDesc.Digest)
 	}

--- a/test/create.bats
+++ b/test/create.bats
@@ -277,8 +277,8 @@ function teardown() {
 	# Verify that the hashes of the blobs and index match (blobs are
 	# content-addressable so using hashes is a bit silly, but whatever).
 	known_hashes=(
-		"6f3716b8ae2bb4b3fd0a851f5a553946ea351ed5fdda0bd708d325363c0487f7  $IMAGE/index.json"
-		"73ecb862d0ebee78acdf8553d34d1ae5c13df509030ac262e561d096bb480dfc  $IMAGE/blobs/sha256/73ecb862d0ebee78acdf8553d34d1ae5c13df509030ac262e561d096bb480dfc"
+		"b780d08bfed4850ab807b7c308682fae6868ed9c09c0c842063c418ebe2a19fb  $IMAGE/index.json"
+		"27bcd3b4f31740cc087346382aaba3fe1c01872d75ead1bd2b9f7053d2bb3231  $IMAGE/blobs/sha256/27bcd3b4f31740cc087346382aaba3fe1c01872d75ead1bd2b9f7053d2bb3231"
 		"e7013826daf8b5d68f82c5b790ca5e9de222a834f2cb3fe3532030161bd72083  $IMAGE/blobs/sha256/e7013826daf8b5d68f82c5b790ca5e9de222a834f2cb3fe3532030161bd72083"
 		"f4a39a97d97aa834da7ad2d92940f9636a57e3d9b3cc7c53242451b02a6cea89  $IMAGE/blobs/sha256/f4a39a97d97aa834da7ad2d92940f9636a57e3d9b3cc7c53242451b02a6cea89"
 	)


### PR DESCRIPTION
Sometimes it is useful to have a reliable estimate of the space that would be taken up by a layer when it is unpacked. Since gzip's headers are only accurate up to 4GiB, larger layers can not be easily measured without uncompressing them.

This commit adds a field to the gzip and zstd compressors to store the bytes read from the stream during compression and uses that to set an annotation on newly generated layers.

If the noop compressor is used, the annotation is not added, as the existing "compressed" layer size would be the same.

Signed-off-by: Michael McCracken <mikmccra@cisco.com>
(cherry picked from commit 8f65e8f75478232b69fa2dd34f550af96dd2e8e2)