### PR TITLE
fix: convert overlay whiteout char dev into userxattr

### DIFF
--- a/oci/layer/types.go
+++ b/oci/layer/types.go
@@ -51,4 +51,7 @@ type RepackOptions struct {
 	// .wh.foo style whiteouts when generating tarballs. Without this,
 	// whiteouts are untouched.
 	TranslateOverlayWhiteouts bool
+
+	// OverlayLowerDirs is a list of unpacked overlay lower dir paths
+	OverlayLowerDirs []string
 }


### PR DESCRIPTION
When extracting a OCI tar layer, a whiteout entry a/.wh.b will be converted to "mknod a/b c 0 0".  However, if in the same layer, we also create a a/b/c entry, it will fail since /a/b is a char dev. In this situation, we remove /a/b and instead set user.overlay.opaque on "a/b".