### PR TITLE
fix: handle whiteout for created dirs

### DIFF
--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -249,9 +249,9 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 					}
 					return ret
 				} else {
-					// skip this since previous layers dont have this file/dir
-					log.Debugf("skipping whiteout since %s not present in any previous layers", pathInTar)
-					return nil
+					// overlayfs adds opaque xattr for newly created dirs,
+					// so we still add this dir into the generated tar
+					return tg.AddFile(pathInTar, curPath)
 				}
 			}
 


### PR DESCRIPTION
When a dir is created, overlayfs adds the opaque xattr. Detect this case and add the dir to the generated tar blob.